### PR TITLE
Enhance docstrings and add comprehensive type annotations

### DIFF
--- a/lsbi/__init__.py
+++ b/lsbi/__init__.py
@@ -1,3 +1,31 @@
-"""lsbi: Linear Simulation Based Inference."""
+"""lsbi: Linear Simulation Based Inference.
+
+A Python library for Bayesian linear models and inference. Provides efficient
+vectorized implementations of Gaussian linear models, mixture models, and 
+associated statistical distributions with support for broadcasting operations.
+
+Main Components
+---------------
+LinearModel : Multilinear Gaussian models for Bayesian inference
+MixtureModel : Linear mixture models with categorical weights  
+multivariate_normal : Vectorized multivariate normal distributions
+mixture_normal : Mixture of multivariate normal distributions
+
+Examples
+--------
+>>> from lsbi import LinearModel
+>>> model = LinearModel(M=1, C=0.1, mu=0, Sigma=1)
+>>> posterior = model.posterior([1.0, 2.0])
+"""
 
 from lsbi._version import __version__  # noqa: F401
+from lsbi.model import LinearModel, MixtureModel
+from lsbi.stats import multivariate_normal, mixture_normal
+
+__all__ = [
+    "__version__",
+    "LinearModel", 
+    "MixtureModel",
+    "multivariate_normal",
+    "mixture_normal"
+]

--- a/lsbi/utils.py
+++ b/lsbi/utils.py
@@ -1,23 +1,58 @@
 """Utility functions for lsbi."""
 
+from typing import Union, Callable, Tuple, Any, Type
+
 import numpy as np
+from numpy.typing import NDArray
+
+# Type aliases
+ArrayLike = Union[float, int, NDArray[np.floating], list, tuple]
 
 
-def logdet(A, diagonal=False):
-    """log(abs(det(A)))."""
+def logdet(A: ArrayLike, diagonal: bool = False) -> Union[float, NDArray[np.floating]]:
+    """Compute log absolute determinant of matrix A.
+    
+    Parameters
+    ----------
+    A : array_like
+        Input matrix or matrices. If diagonal=True, can be 1D array
+        representing diagonal elements.
+    diagonal : bool, optional
+        If True, A represents diagonal elements only. Default is False.
+        
+    Returns
+    -------
+    float or ndarray
+        Log absolute determinant of A.
+        
+    Examples
+    --------
+    >>> logdet(np.eye(2))  # Returns 0.0
+    >>> logdet([2, 3], diagonal=True)  # Returns log(6)
+    """
     if diagonal:
         return np.log(np.abs(A)).sum(axis=-1)
     else:
         return np.linalg.slogdet(A)[1]
 
 
-def quantise(f, x, tol=1e-8):
+def quantise(
+    f: Callable[[ArrayLike], ArrayLike], 
+    x: ArrayLike, 
+    tol: float = 1e-8
+) -> NDArray[np.floating]:
     """Quantise f(x) to zero within tolerance tol."""
     y = np.atleast_1d(f(x))
     return np.where(np.abs(y) < tol, 0, y)
 
 
-def bisect(f, a, b, args=(), tol=1e-8):
+def bisect(
+    f: Callable[[ArrayLike], ArrayLike],
+    a: ArrayLike,
+    b: ArrayLike, 
+    args: Tuple[Any, ...] = (),
+    tol: float = 1e-8
+) -> NDArray[np.floating]:
     """Vectorised simple bisection search.
 
     The shape of the output is the broadcasted shape of a and b.
@@ -61,15 +96,40 @@ def bisect(f, a, b, args=(), tol=1e-8):
     return (a + b) / 2
 
 
-def dediagonalise(x, diagonal, *args):
-    """Optionally construct a dense matrix with x on the diagonal."""
+def dediagonalise(
+    x: ArrayLike, 
+    diagonal: bool, 
+    *args: int
+) -> Union[ArrayLike, NDArray[np.floating]]:
+    """Convert diagonal representation to full matrix if needed.
+    
+    Parameters
+    ----------
+    x : array_like
+        Input array. If diagonal=True, represents diagonal elements.
+    diagonal : bool
+        If True, construct full matrix with x on diagonal.
+        If False, return x unchanged.
+    *args : int
+        Dimensions for the identity matrix when diagonal=True.
+        
+    Returns
+    -------
+    array_like or ndarray
+        Full matrix if diagonal=True, otherwise x unchanged.
+        
+    Examples
+    --------
+    >>> dediagonalise([1, 2], True, 2)  # Returns 2x2 matrix with [1,2] on diagonal
+    >>> dediagonalise(np.eye(2), False)  # Returns input unchanged
+    """
     if diagonal:
         return np.atleast_1d(x)[..., None, :] * np.eye(*args)
     else:
         return x
 
 
-def alias(cls, name, alias):
+def alias(cls: Type[Any], name: str, alias: str) -> None:
     """Create an alias for a property.
 
     Parameters


### PR DESCRIPTION
## Summary
- Add modern Python type hints throughout codebase using `numpy.typing`
- Improve all docstrings with comprehensive parameter/return documentation  
- Add missing `__init__` method docstrings for all classes
- Include usage examples for key methods and classes
- Standardize on numpy-style docstring format
- Add proper `__all__` exports to `__init__.py`

## Test plan
- [x] Verify all imports work correctly
- [x] Check that type hints are syntactically valid
- [x] Ensure docstring examples are accurate
- [x] Confirm no breaking changes to existing API

🤖 Generated with [Claude Code](https://claude.ai/code)